### PR TITLE
data preprocessing for motion correction

### DIFF
--- a/config/param.yml
+++ b/config/param.yml
@@ -30,7 +30,7 @@ motion_all: &id003
 # database name
 MRdatabase : MRPhysics
 # subdirectories in database, patient, output directory
-subdirs : ["newProtocol", "dicom_sorted", "testout"]
+subdirs : ["newProtocol", "dicom_sorted", "testout", "correction"]
 # CNN database to be modeled
 selectedDatabase: *id001
 # network architecture (if existing for chosen database!)
@@ -84,7 +84,11 @@ lLabelPredictImg : [ 1 ]
 # "scalingPosterior": scaling during training, to be done
 sTrainingMethod : "None"
 lScaleFactor : [0.5, 1, 2]
+
 # lCorrection
 # true: artifact correction
 # false: classification
 lCorrection: false
+# parameters in artifacts correction
+correction:
+  sCorrection: "motion"

--- a/config/param.yml
+++ b/config/param.yml
@@ -84,3 +84,7 @@ lLabelPredictImg : [ 1 ]
 # "scalingPosterior": scaling during training, to be done
 sTrainingMethod : "None"
 lScaleFactor : [0.5, 1, 2]
+# lCorrection
+# true: artifact correction
+# false: classification
+lCorrection: false

--- a/correction/main_correction.py
+++ b/correction/main_correction.py
@@ -17,7 +17,7 @@ def fPatching(cfg, dbinfo):
     dArtPats = np.empty((0, 1))
 
     lDatasets = cfg['selectedDatabase']['dataref'] + cfg['selectedDatabase']['dataart']
-    for ipat, pat in enumerate(dbinfo.lPats[0:2]):
+    for ipat, pat in enumerate(dbinfo.lPats):
         if os.path.exists(dbinfo.sPathIn + os.sep + pat + os.sep + dbinfo.sSubDirs[1]):
             for iseq, seq in enumerate(lDatasets):
                 # patches and labels of reference/artifact
@@ -94,10 +94,18 @@ def fSplitDataset(sSplitting, dRefPatches, dArtPatches, allPats, split_ratio, nf
 
 def run(cfg, dbinfo):
     patchSize = cfg['patchSize']
+
+    if cfg['sSplitting'] == 'normal':
+        sFSname = 'normal'
+    elif cfg['sSplitting'] == 'crossvalidation_data':
+        sFSname = 'crossVal_data'
+    elif cfg['sSplitting'] == 'crossvalidation_patient':
+        sFSname = 'crossVal'
+
     sOutsubdir = cfg['subdirs'][3]
     sOutPath = cfg['selectedDatabase']['pathout'] + os.sep \
                + ''.join(map(str, patchSize)).replace(" ", "") + os.sep + sOutsubdir
-    sDatafile = sOutPath + os.sep + ''.join(map(str, patchSize)).replace(" ", "") + '.h5'
+    sDatafile = sOutPath + os.sep + sFSname + ''.join(map(str, patchSize)).replace(" ", "") + '.h5'
 
     # if h5 file exists
     if glob.glob(sDatafile):

--- a/correction/main_correction.py
+++ b/correction/main_correction.py
@@ -1,2 +1,65 @@
-def run(cfg, dbinfo):
+# external import
+import glob
+import os
+import h5py
+import numpy as np
+
+# internal import
+import utils.DataPreprocessing as datapre
+
+def fPatching(cfg, dbinfo):
+    patchSize = cfg['patchSize']
+    dAllPatches = np.zeros((0, patchSize[0], patchSize[1]))
+    dAllLabels = np.zeros(0)
+    dAllPats = np.zeros((0, 1))
+
+    lDatasets = cfg['selectedDatabase']['dataref'] + cfg['selectedDatabase']['dataart']
+    iLabels = cfg['selectedDatabase']['labelref'] + cfg['selectedDatabase']['labelart']
+    for ipat, pat in enumerate(dbinfo.lPats):
+        if os.path.exists(dbinfo.sPathIn + os.sep + pat + os.sep + dbinfo.sSubDirs[1]):
+            for iseq, seq in enumerate(lDatasets):
+                # patches and labels of reference/artifact
+                tmpPatches, tmpLabels = datapre.fPreprocessData(
+                    os.path.join(dbinfo.sPathIn, pat, dbinfo.sSubDirs[1], seq), patchSize, cfg['patchOverlap'], 1,
+                    'volume')
+                dAllPatches = np.concatenate((dAllPatches, tmpPatches), axis=0)
+                dAllLabels = np.concatenate((dAllLabels, iLabels[iseq] * tmpLabels), axis=0)
+                dAllPats = np.concatenate((dAllPats, ipat * np.ones((tmpLabels.shape[0], 1), dtype=np.int)), axis=0)
+        else:
+            pass
+
+    iRefPatches = np.where(dAllLabels == iLabels[0])[0]
+    iCorPatches = np.where(dAllLabels == iLabels[1])[0]
+    dRefPatches, dCorPatches = dAllLabels[iRefPatches, :, :], dAllLabels[iCorPatches, :, :]
+
+    return dRefPatches, dCorPatches
+
+def fSplitDataset():
     pass
+
+def run(cfg, dbinfo):
+    lPatching = cfg['correction']['lPatching']
+    patchSize = cfg['patchSize']
+    sOutsubdir = cfg['subdirs'][3]
+    sOutPath = cfg['selectedDatabase']['pathout'] + os.sep \
+               + ''.join(map(str, patchSize)).replace(" ", "") + os.sep + sOutsubdir
+    sDatafile = sOutPath + os.sep + ''.join(map(str, patchSize)).replace(" ", "") + '.h5'
+
+    # if h5 file exists
+    if glob.glob(sDatafile):
+        with h5py.File(sDatafile, 'r') as hf:
+            X_train_reference = hf['X_train_reference'][:]
+            X_train_corrupted = hf['X_train_corrupted'][:]
+            X_test_reference = hf['X_test_reference'][:]
+            X_test_corrupted = hf['X_test_corrupted'][:]
+            patchSize = hf['patchSize'][:]
+
+    else:
+        # perform patching
+        dRefPatches, dCorPatches = fPatching(cfg, dbinfo)
+
+        # perform splitting
+
+
+
+

--- a/correction/main_correction.py
+++ b/correction/main_correction.py
@@ -3,39 +3,94 @@ import glob
 import os
 import h5py
 import numpy as np
+from sklearn.model_selection import KFold
+import math
 
 # internal import
 import utils.DataPreprocessing as datapre
 
 def fPatching(cfg, dbinfo):
     patchSize = cfg['patchSize']
-    dAllPatches = np.zeros((0, patchSize[0], patchSize[1]))
-    dAllLabels = np.zeros(0)
-    dAllPats = np.zeros((0, 1))
+    dRefPatches = np.empty((0, patchSize[0], patchSize[1]))
+    dArtPatches = np.empty((0, patchSize[0], patchSize[1]))
+    dRefPats = np.empty((0, 1))
+    dArtPats = np.empty((0, 1))
 
     lDatasets = cfg['selectedDatabase']['dataref'] + cfg['selectedDatabase']['dataart']
-    iLabels = cfg['selectedDatabase']['labelref'] + cfg['selectedDatabase']['labelart']
-    for ipat, pat in enumerate(dbinfo.lPats):
+    for ipat, pat in enumerate(dbinfo.lPats[0:2]):
         if os.path.exists(dbinfo.sPathIn + os.sep + pat + os.sep + dbinfo.sSubDirs[1]):
             for iseq, seq in enumerate(lDatasets):
                 # patches and labels of reference/artifact
-                tmpPatches, tmpLabels = datapre.fPreprocessData(
-                    os.path.join(dbinfo.sPathIn, pat, dbinfo.sSubDirs[1], seq), patchSize, cfg['patchOverlap'], 1,
-                    'volume')
-                dAllPatches = np.concatenate((dAllPatches, tmpPatches), axis=0)
-                dAllLabels = np.concatenate((dAllLabels, iLabels[iseq] * tmpLabels), axis=0)
-                dAllPats = np.concatenate((dAllPats, ipat * np.ones((tmpLabels.shape[0], 1), dtype=np.int)), axis=0)
+                tmpPatches, tmpLabels = datapre.fPreprocessData(os.path.join(dbinfo.sPathIn, pat, dbinfo.sSubDirs[1], seq),
+                                                                patchSize, cfg['patchOverlap'], 1, 'volume')
+
+                if iseq == 0:
+                    dRefPatches = np.concatenate((dRefPatches, tmpPatches), axis=0)
+                    dRefPats = np.concatenate((dRefPats, ipat * np.ones((tmpPatches.shape[0], 1), dtype=np.int)), axis=0)
+                elif iseq == 1:
+                    dArtPatches = np.concatenate((dArtPatches, tmpPatches), axis=0)
+                    dArtPats = np.concatenate((dArtPats, ipat * np.ones((tmpPatches.shape[0], 1), dtype=np.int)), axis=0)
         else:
             pass
 
-    iRefPatches = np.where(dAllLabels == iLabels[0])[0]
-    iCorPatches = np.where(dAllLabels == iLabels[1])[0]
-    dRefPatches, dCorPatches = dAllLabels[iRefPatches], dAllLabels[iCorPatches]
+    assert(dRefPatches.shape == dArtPatches.shape and dRefPats.shape == dArtPats.shape)
 
-    return dRefPatches, dCorPatches
+    return dRefPatches, dArtPatches, dRefPats
 
-def fSplitDataset():
-    pass
+def fSplitDataset(sSplitting, dRefPatches, dArtPatches, allPats, split_ratio, nfolds):
+    train_ref_fold = []
+    test_ref_fold = []
+    train_art_fold = []
+    test_art_fold = []
+
+    # normal splitting
+    if sSplitting == 'normal':
+        nPatches = dRefPatches.shape[0]
+        dVal = math.floor(split_ratio * nPatches)
+        rand_num = np.random.permutation(np.arange(nPatches))
+        rand_num = rand_num[0:int(dVal)].astype(int)
+
+        test_ref_fold = dRefPatches[rand_num, :, :]
+        train_ref_fold = np.delete(dRefPatches, rand_num, axis=0)
+        test_art_fold = dArtPatches[rand_num, :, :]
+        train_art_fold = np.delete(dArtPatches, rand_num, axis=0)
+
+    # crossvalidation with mixed patient
+    if sSplitting == "crossvalidation_data":
+        if nfolds == 0:
+            kf = KFold(n_splits=len(np.unique(allPats)))
+        else:
+            kf = KFold(n_splits=nfolds)
+
+        for train_index, test_index in kf.split(dRefPatches):
+            train_ref, test_ref = dRefPatches[train_index], dRefPatches[test_index]
+            train_art, test_art = dArtPatches[train_index], dArtPatches[test_index]
+
+            train_ref_fold.append(train_ref)
+            train_art_fold.append(train_art)
+            test_ref_fold.append(test_ref)
+            test_art_fold.append(test_art)
+
+    elif sSplitting == 'crossvalidation_patient':
+        unique_pats = np.unique(allPats)
+
+        for ind_split in unique_pats:
+            train_index = np.where(allPats != ind_split)[0]
+            test_index = np.where(allPats == ind_split)[0]
+            train_ref, test_ref = dRefPatches[train_index], dRefPatches[test_index]
+            train_art, test_art = dArtPatches[train_index], dArtPatches[test_index]
+
+            train_ref_fold.append(train_ref)
+            train_art_fold.append(train_art)
+            test_ref_fold.append(test_ref)
+            test_art_fold.append(test_art)
+
+    train_ref_fold = np.asarray(train_ref_fold, dtype='f')
+    train_art_fold = np.asarray(train_art_fold, dtype='f')
+    test_ref_fold = np.asarray(test_ref_fold, dtype='f')
+    test_art_fold = np.asarray(test_art_fold, dtype='f')
+
+    return train_ref_fold, test_ref_fold, train_art_fold, test_art_fold
 
 def run(cfg, dbinfo):
     patchSize = cfg['patchSize']
@@ -47,19 +102,28 @@ def run(cfg, dbinfo):
     # if h5 file exists
     if glob.glob(sDatafile):
         with h5py.File(sDatafile, 'r') as hf:
-            X_train_reference = hf['X_train_reference'][:]
-            X_train_corrupted = hf['X_train_corrupted'][:]
-            X_test_reference = hf['X_test_reference'][:]
-            X_test_corrupted = hf['X_test_corrupted'][:]
+            train_ref = hf['train_ref'][:]
+            train_art = hf['train_art'][:]
+            test_ref = hf['test_ref'][:]
+            test_art = hf['test_art'][:]
             patchSize = hf['patchSize'][:]
 
     else:
         # perform patching
-        dRefPatches, dCorPatches = fPatching(cfg, dbinfo)
-	print(dRefPatches.shape)
-	print(dCorPatches.shape)
+        dRefPatches, dArtPatches, dAllPats = fPatching(cfg, dbinfo)
+
+        print(dRefPatches.shape)
+        print(dArtPatches.shape)
+        print(dAllPats.shape)
+
         # perform splitting
+        train_ref, test_ref, train_art, test_art = fSplitDataset(cfg['sSplitting'], dRefPatches, dArtPatches, dAllPats, cfg['dSplitval'], cfg['nFolds'])
 
-
-
-
+        # save to h5 file
+        if cfg['lSave']:
+            with h5py.File(sDatafile, 'w') as hf:
+                hf.create_dataset('train_ref', data=train_ref)
+                hf.create_dataset('test_ref', data=test_ref)
+                hf.create_dataset('train_art', data=train_art)
+                hf.create_dataset('test_art', data=test_art)
+                hf.create_dataset('patchSize', data=patchSize)

--- a/correction/main_correction.py
+++ b/correction/main_correction.py
@@ -1,0 +1,2 @@
+def run(cfg, dbinfo):
+    pass

--- a/correction/main_correction.py
+++ b/correction/main_correction.py
@@ -30,7 +30,7 @@ def fPatching(cfg, dbinfo):
 
     iRefPatches = np.where(dAllLabels == iLabels[0])[0]
     iCorPatches = np.where(dAllLabels == iLabels[1])[0]
-    dRefPatches, dCorPatches = dAllLabels[iRefPatches, :, :], dAllLabels[iCorPatches, :, :]
+    dRefPatches, dCorPatches = dAllLabels[iRefPatches], dAllLabels[iCorPatches]
 
     return dRefPatches, dCorPatches
 
@@ -38,7 +38,6 @@ def fSplitDataset():
     pass
 
 def run(cfg, dbinfo):
-    lPatching = cfg['correction']['lPatching']
     patchSize = cfg['patchSize']
     sOutsubdir = cfg['subdirs'][3]
     sOutPath = cfg['selectedDatabase']['pathout'] + os.sep \
@@ -57,7 +56,8 @@ def run(cfg, dbinfo):
     else:
         # perform patching
         dRefPatches, dCorPatches = fPatching(cfg, dbinfo)
-
+	print(dRefPatches.shape)
+	print(dCorPatches.shape)
         # perform splitting
 
 

--- a/correction/main_correction.py
+++ b/correction/main_correction.py
@@ -2,116 +2,10 @@
 import glob
 import os
 import h5py
-import numpy as np
-from sklearn.model_selection import KFold
-import math
 
 # internal import
 import utils.DataPreprocessing as datapre
-
-def fPatching(cfg, dbinfo):
-    """
-    Perform patching to reference and artifact images according to given patch size.
-    @param cfg: the configuration file loaded from config/param.yml
-    @param dbinfo: database related info
-    @return: patches from reference and artifact images and an array which stores the corresponding patient index
-    """
-    patchSize = cfg['patchSize']
-    dRefPatches = np.empty((0, patchSize[0], patchSize[1]))
-    dArtPatches = np.empty((0, patchSize[0], patchSize[1]))
-    dRefPats = np.empty((0, 1))
-    dArtPats = np.empty((0, 1))
-
-    lDatasets = cfg['selectedDatabase']['dataref'] + cfg['selectedDatabase']['dataart']
-    for ipat, pat in enumerate(dbinfo.lPats):
-        if os.path.exists(dbinfo.sPathIn + os.sep + pat + os.sep + dbinfo.sSubDirs[1]):
-            for iseq, seq in enumerate(lDatasets):
-                # patches and labels of reference/artifact
-                tmpPatches, tmpLabels = datapre.fPreprocessData(os.path.join(dbinfo.sPathIn, pat, dbinfo.sSubDirs[1], seq),
-                                                                patchSize, cfg['patchOverlap'], 1, 'volume')
-
-                if iseq == 0:
-                    dRefPatches = np.concatenate((dRefPatches, tmpPatches), axis=0)
-                    dRefPats = np.concatenate((dRefPats, ipat * np.ones((tmpPatches.shape[0], 1), dtype=np.int)), axis=0)
-                elif iseq == 1:
-                    dArtPatches = np.concatenate((dArtPatches, tmpPatches), axis=0)
-                    dArtPats = np.concatenate((dArtPats, ipat * np.ones((tmpPatches.shape[0], 1), dtype=np.int)), axis=0)
-        else:
-            pass
-
-    assert(dRefPatches.shape == dArtPatches.shape and dRefPats.shape == dArtPats.shape)
-
-    return dRefPatches, dArtPatches, dRefPats
-
-
-def fSplitDataset(sSplitting, dRefPatches, dArtPatches, allPats, split_ratio, nfolds):
-    """
-    Split dataset with three options:
-    1. normal: randomly split data according to the split_ratio without cross validation
-    2. crossvalidation_data: perform crossvalidation with mixed patient data
-    3. crossvalidation_patient: perform crossvalidation with separate patient data
-    @param sSplitting: splitting mode 'normal', 'crossvalidation_data' or 'crossvalidation_patient'
-    @param dRefPatches: reference patches
-    @param dArtPatches: artifact patches
-    @param allPats: patient index
-    @param split_ratio: the ratio to split test data
-    @param nfolds: folds for cross validation
-    @return: testing and training data for both reference and artifact images
-    """
-    train_ref_fold = []
-    test_ref_fold = []
-    train_art_fold = []
-    test_art_fold = []
-
-    # normal splitting
-    if sSplitting == 'normal':
-        nPatches = dRefPatches.shape[0]
-        dVal = math.floor(split_ratio * nPatches)
-        rand_num = np.random.permutation(np.arange(nPatches))
-        rand_num = rand_num[0:int(dVal)].astype(int)
-
-        test_ref_fold = dRefPatches[rand_num, :, :]
-        train_ref_fold = np.delete(dRefPatches, rand_num, axis=0)
-        test_art_fold = dArtPatches[rand_num, :, :]
-        train_art_fold = np.delete(dArtPatches, rand_num, axis=0)
-
-    # crossvalidation with mixed patient
-    if sSplitting == "crossvalidation_data":
-        if nfolds == 0:
-            kf = KFold(n_splits=len(np.unique(allPats)))
-        else:
-            kf = KFold(n_splits=nfolds)
-
-        for train_index, test_index in kf.split(dRefPatches):
-            train_ref, test_ref = dRefPatches[train_index], dRefPatches[test_index]
-            train_art, test_art = dArtPatches[train_index], dArtPatches[test_index]
-
-            train_ref_fold.append(train_ref)
-            train_art_fold.append(train_art)
-            test_ref_fold.append(test_ref)
-            test_art_fold.append(test_art)
-
-    # crossvalidation with separate patient
-    elif sSplitting == 'crossvalidation_patient':
-        unique_pats = np.unique(allPats)
-
-        for ind_split in unique_pats:
-            train_index = np.where(allPats != ind_split)[0]
-            test_index = np.where(allPats == ind_split)[0]
-            train_ref, test_ref = dRefPatches[train_index], dRefPatches[test_index]
-            train_art, test_art = dArtPatches[train_index], dArtPatches[test_index]
-
-            train_ref_fold.append(train_ref)
-            train_art_fold.append(train_art)
-            test_ref_fold.append(test_ref)
-            test_art_fold.append(test_art)
-
-    train_ref_fold = np.asarray(train_ref_fold, dtype='f')
-    train_art_fold = np.asarray(train_art_fold, dtype='f')
-    test_ref_fold = np.asarray(test_ref_fold, dtype='f')
-    test_art_fold = np.asarray(test_art_fold, dtype='f')
-
-    return train_ref_fold, test_ref_fold, train_art_fold, test_art_fold
+import utils.Training_Test_Split as ttsplit
 
 def run(cfg, dbinfo):
     """
@@ -145,10 +39,10 @@ def run(cfg, dbinfo):
 
     else:
         # perform patching
-        dRefPatches, dArtPatches, dAllPats = fPatching(cfg, dbinfo)
+        dRefPatches, dArtPatches, dAllPats = datapre.fPreprocessDataCorrection(cfg, dbinfo)
 
         # perform splitting
-        train_ref, test_ref, train_art, test_art = fSplitDataset(cfg['sSplitting'], dRefPatches, dArtPatches, dAllPats, cfg['dSplitval'], cfg['nFolds'])
+        train_ref, test_ref, train_art, test_art = ttsplit.fSplitDatasetCorrection(cfg['sSplitting'], dRefPatches, dArtPatches, dAllPats, cfg['dSplitval'], cfg['nFolds'])
 
         # save to h5 file
         if cfg['lSave']:

--- a/main.py
+++ b/main.py
@@ -10,13 +10,15 @@ import utils.DataPreprocessing as datapre
 import utils.Training_Test_Split as ttsplit
 import cnn_main
 import utils.scaling as scaling
-
+import correction.main_correction as correction
 
 with open('config' + os.sep + 'param.yml', 'r') as ymlfile:
     cfg = yaml.safe_load(ymlfile)
 
 lTrain = cfg['lTrain'] # training or prediction
 lSave = cfg['lSave'] # save intermediate test, training sets
+lCorrection = cfg['lCorrection'] # artifact correction or classification
+
 # initiate info objects
 # default database: MRPhysics with ['newProtocol','dicom_sorted']
 dbinfo = DatabaseInfo(cfg['MRdatabase'],cfg['subdirs'])
@@ -36,10 +38,16 @@ sOutsubdir = cfg['subdirs'][2]
 sOutPath = cfg['selectedDatabase']['pathout'] + os.sep + ''.join(map(str,patchSize)).replace(" ", "") + os.sep + sOutsubdir # + str(ind_split) + '_' + str(patchSize[0]) + str(patchSize[1]) + '.h5'
 sDatafile = sOutPath + os.sep + sFSname + ''.join(map(str,patchSize)).replace(" ", "") + '.h5'
 
-##############
-## training ##
-##############
-if lTrain:
+if lCorrection:
+    #########################
+    ## Artifact Correction ##
+    #########################
+    correction.run(cfg, dbinfo)
+
+elif lTrain:
+    ##############
+    ## training ##
+    ##############
     # check if file is already existing -> skip patching
     if glob.glob(sOutPath + os.sep + sFSname + ''.join(map(str,patchSize)).replace(" ", "") + '*_input.mat'): # deprecated
         sDatafile = sOutPath + os.sep + sFSname + ''.join(map(str,patchSize)).replace(" ", "") + '_input.mat'

--- a/utils/Training_Test_Split.py
+++ b/utils/Training_Test_Split.py
@@ -167,3 +167,72 @@ def fSplitDataset(allPatches, allY, allPats, sSplitting, patchSize, patchOverlap
 
         if iReturn > 0:
             return X_trainFold, y_trainFold, X_testFold, y_testFold
+
+def fSplitDatasetCorrection(sSplitting, dRefPatches, dArtPatches, allPats, split_ratio, nfolds):
+    """
+    Split dataset with three options:
+    1. normal: randomly split data according to the split_ratio without cross validation
+    2. crossvalidation_data: perform crossvalidation with mixed patient data
+    3. crossvalidation_patient: perform crossvalidation with separate patient data
+    @param sSplitting: splitting mode 'normal', 'crossvalidation_data' or 'crossvalidation_patient'
+    @param dRefPatches: reference patches
+    @param dArtPatches: artifact patches
+    @param allPats: patient index
+    @param split_ratio: the ratio to split test data
+    @param nfolds: folds for cross validation
+    @return: testing and training data for both reference and artifact images
+    """
+    train_ref_fold = []
+    test_ref_fold = []
+    train_art_fold = []
+    test_art_fold = []
+
+    # normal splitting
+    if sSplitting == 'normal':
+        nPatches = dRefPatches.shape[0]
+        dVal = math.floor(split_ratio * nPatches)
+        rand_num = np.random.permutation(np.arange(nPatches))
+        rand_num = rand_num[0:int(dVal)].astype(int)
+
+        test_ref_fold = dRefPatches[rand_num, :, :]
+        train_ref_fold = np.delete(dRefPatches, rand_num, axis=0)
+        test_art_fold = dArtPatches[rand_num, :, :]
+        train_art_fold = np.delete(dArtPatches, rand_num, axis=0)
+
+    # crossvalidation with mixed patient
+    if sSplitting == "crossvalidation_data":
+        if nfolds == 0:
+            kf = KFold(n_splits=len(np.unique(allPats)))
+        else:
+            kf = KFold(n_splits=nfolds)
+
+        for train_index, test_index in kf.split(dRefPatches):
+            train_ref, test_ref = dRefPatches[train_index], dRefPatches[test_index]
+            train_art, test_art = dArtPatches[train_index], dArtPatches[test_index]
+
+            train_ref_fold.append(train_ref)
+            train_art_fold.append(train_art)
+            test_ref_fold.append(test_ref)
+            test_art_fold.append(test_art)
+
+    # crossvalidation with separate patient
+    elif sSplitting == 'crossvalidation_patient':
+        unique_pats = np.unique(allPats)
+
+        for ind_split in unique_pats:
+            train_index = np.where(allPats != ind_split)[0]
+            test_index = np.where(allPats == ind_split)[0]
+            train_ref, test_ref = dRefPatches[train_index], dRefPatches[test_index]
+            train_art, test_art = dArtPatches[train_index], dArtPatches[test_index]
+
+            train_ref_fold.append(train_ref)
+            train_art_fold.append(train_art)
+            test_ref_fold.append(test_ref)
+            test_art_fold.append(test_art)
+
+    train_ref_fold = np.asarray(train_ref_fold, dtype='f')
+    train_art_fold = np.asarray(train_art_fold, dtype='f')
+    test_ref_fold = np.asarray(test_ref_fold, dtype='f')
+    test_art_fold = np.asarray(test_art_fold, dtype='f')
+
+    return train_ref_fold, test_ref_fold, train_art_fold, test_art_fold


### PR DESCRIPTION
1. My plan is to put all the correction related parameters under `correction` in `param.yml`. 

2. create a parameter `sCorrection` under `correction` to specify the kind of artifact to be corrected. e.g. `motion`

3. create a param `lCorrection` in `param.yml` to specify the classification (false) or correction (true)

4. add a new subdir `correction` in `subdirs` - set as the output path of correction related stuff

5. create folder `correction` and `main_correction.py` inside and add following three functions in it.
- `run`: the main interface for correction
- `fPatching`: patching for correction
- `fSplitDataset`: perform three splitting methods for correction

Following diagram shows the structure of data pre-processing for correction:


![datapre](https://www.dropbox.com/s/2q2ulueohqc158d/datapre.png?raw=1)
 
I have to further confirm the patches from reference and artifact images are one-to-one correspondence.

I'm not sure if it is suitable to put the `fPatching` and `fSplitDataset` into `main_correction.py` file. But they are quite different from the normal patching and splitting in `utils` folder. Do you have any suggestion? @thomaskuestner 