### PR TITLE
fix typo and wrong intend

### DIFF
--- a/utils/Patching.py
+++ b/utils/Patching.py
@@ -34,7 +34,7 @@ def fRigidPatching(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_array,
     Img_zero_pad = np.lib.pad(dicom_numpy_array, (
     (zero_pad_part[0], zero_pad[0] - zero_pad_part[0]), (zero_pad_part[1], zero_pad[1] - zero_pad_part[1]), (0, 0)),
                               mode='constant')
-	nbPatches = int(((size_zero_pad[0]-patchSize[0])/((1-patchOverlap)*patchSize[0])+1)*((size_zero_pad[1]-patchSize[1])/((1-patchOverlap)*patchSize[1])+1)*dicom_numpy_array.shape[2])
+    nbPatches = int(((size_zero_pad[0]-patchSize[0])/((1-patchOverlap)*patchSize[0])+1)*((size_zero_pad[1]-patchSize[1])/((1-patchOverlap)*patchSize[1])+1)*dicom_numpy_array.shape[2])
     dPatches = np.zeros((patchSize[0], patchSize[1], nbPatches), dtype=float) #dtype=np.float32
     dLabels = np.zeros((nbPatches), dtype = float) #dtype = float
     idxPatch = 0
@@ -44,8 +44,8 @@ def fRigidPatching(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_array,
                 for iX in range(0, int(size_zero_pad[1] - dOverlap[1]), int(dNotOverlap[1])):
                     dPatch = Img_zero_pad[iY:iY + patchSize[0], iX:iX + patchSize[1], iZ]
                     dPatches[:,:,idxPatch] = dPatch
-					idxPatch += 1
-					
+                    idxPatch += 1
+
         dLabels = np.ones((dPatches.shape[2]))
     elif sLabeling == 'patch':
         Mask_zero_pad = np.lib.pad(mask_numpy_array, (
@@ -86,13 +86,13 @@ def fRigidPatching(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_array,
                         label = 7
 
                     dLabels[idxPatch] = label
-					idxPatch += 1
+                    idxPatch += 1
 
                     move_artefact = False
                     shim_artefact = False
                     noise_artefact = False
 
-    return dPatches, dLabels, nbPatches
+    return dPatches, dLabels
 ##########################################################################################################################################
 # In case of 3D patches:                                                                                                                 #
 #Input: dicom_numpy_array ---> 4D dicom array (height, width, lengh, number of slices)                                                   #
@@ -105,11 +105,11 @@ def fRigidPatching(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_array,
 #        dLabels ---> 1D-Numpy-Array with all corresponding labels                                                                       #
 ##########################################################################################################################################
 def fRigidPatching3D(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_array, ratio_labeling, sLabeling):
-    
+
     move_artefact = False
     shim_artefact = False
     noise_artefact = False
-    
+
 
     dOverlap = np.multiply(patchSize, patchOverlap)
     dNotOverlap = np.ceil(np.multiply(patchSize, (1 - patchOverlap)))
@@ -121,10 +121,10 @@ def fRigidPatching3D(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_arra
     Img_zero_pad = np.lib.pad(dicom_numpy_array, ((zero_pad_part[0], zero_pad[0] - zero_pad_part[0]), (zero_pad_part[1], zero_pad[1] - zero_pad_part[1]), (zero_pad_part[2], zero_pad[2] - zero_pad_part[2])),
                               mode='constant')
 
-	nbPatches = ((size_zero_pad[0]-patchSize[0])/((1-patchOverlap)*patchSize[0])+1)*((size_zero_pad[1]-patchSize[1])/((1-patchOverlap)*patchSize[1])+1)*((size_zero_pad[2]-patchSize[2])/(np.round((1-patchOverlap)*patchSize[2]))+1)
-	dPatches = np.zeros((patchSize[0], patchSize[1], patchSize[2], int(nbPatches)), dtype=float)
-	dLabels = np.zeros((int(nbPatches)), dtype = int) #float
-	idxPatch = 0
+    nbPatches = ((size_zero_pad[0]-patchSize[0])/((1-patchOverlap)*patchSize[0])+1)*((size_zero_pad[1]-patchSize[1])/((1-patchOverlap)*patchSize[1])+1)*((size_zero_pad[2]-patchSize[2])/(np.round((1-patchOverlap)*patchSize[2]))+1)
+    dPatches = np.zeros((patchSize[0], patchSize[1], patchSize[2], int(nbPatches)), dtype=float)
+    dLabels = np.zeros((int(nbPatches)), dtype = int) #float
+    idxPatch = 0
 
     if sLabeling == 'volume':
         for iZ in range(0, int(size_zero_pad[2] - dOverlap[2]), int(dNotOverlap[2])):
@@ -132,14 +132,14 @@ def fRigidPatching3D(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_arra
                 for iX in range(0, int(size_zero_pad[1] - dOverlap[1]), int(dNotOverlap[1])):
                     dPatch = Img_zero_pad[iY:iY + patchSize[0], iX:iX + patchSize[1], iZ:iZ + patchSize[2]]
                     dPatches[:,:,:,idxPatch] = dPatch
-					idxPatch += 1
-					
+                    idxPatch += 1
+
         dLabels = np.ones((dPatches.shape[3]))
     elif sLabeling == 'patch':
         Mask_zero_pad = np.lib.pad(mask_numpy_array, (
-    (zero_pad_part[0], zero_pad[0] - zero_pad_part[0]), (zero_pad_part[1], zero_pad[1] - zero_pad_part[1]), (0, 0)),
-                              mode='constant
-		for iZ in range(0, int(size_zero_pad[2] - dOverlap[2]), int(dNotOverlap[2])):
+            (zero_pad_part[0], zero_pad[0] - zero_pad_part[0]), (zero_pad_part[1], zero_pad[1] - zero_pad_part[1]), (0, 0)),
+                                   mode='constant')
+        for iZ in range(0, int(size_zero_pad[2] - dOverlap[2]), int(dNotOverlap[2])):
             for iY in range(0, int(size_zero_pad[0] - dOverlap[0]), int(dNotOverlap[0])):
                 for iX in range(0, int(size_zero_pad[1] - dOverlap[1]), int(dNotOverlap[1])):
                     dPatch = Img_zero_pad[iY:iY + patchSize[0], iX:iX + patchSize[1], iZ:iZ + patchSize[2]]
@@ -173,10 +173,10 @@ def fRigidPatching3D(dicom_numpy_array, patchSize, patchOverlap, mask_numpy_arra
                         label = 7
 
                     dLabels[idxPatch] = label
-					idxPatch += 1
+                    idxPatch += 1
 
                     move_artefact = False
                     shim_artefact = False
                     noise_artefact = False
 
-    return dPatches, dLabels, nbPatches
+    return dPatches, dLabels


### PR DESCRIPTION
1. fix typo and wrong intend
2. remove `nbPatch` in `fRigidPatching` and `fRigidPatching3D`: this variable returns the number of patches, which is not needed in DataPreprocessing